### PR TITLE
Remove unacessary logs and change others

### DIFF
--- a/main.py
+++ b/main.py
@@ -99,7 +99,6 @@ class GenericFlow(object):
         match = dict()
         for name in self.match:
             match[name] = self.match[name].value
-        log.info('Match %s' % match)
         return match
 
     def to_json(self):
@@ -609,6 +608,7 @@ class Main(KytosNApp):
         # pylint: disable=unused-argument
         if error:
             msg = 'Flow info not installed'
+            log.error(msg)
         else:
             msg = 'Flow info installed sucessfully'
-        log.info(msg)
+            log.debug(msg)


### PR DESCRIPTION
Remove logs of matches, and change the log level of object creation in storehouse; instead of always logging to `info`, now logs to `error` when there is an error or to `debug` otherwise.

Fixes #1.