### PR TITLE
[Fix] GET /api/amlight/flow_stats/flow/stats/ not found

### DIFF
--- a/main.py
+++ b/main.py
@@ -337,6 +337,8 @@ class Main(KytosNApp):
     def flow_stats(self, dpid):
         """Return all flows matching request."""
         switch = self.controller.get_switch_by_dpid(dpid)
+        if not switch:
+            return f"switch {dpid} not found", 404
         flows = self.match_flows(switch, format_request(request.args), True)
         flows = [flow.to_dict() for flow in flows]
         return jsonify(flows)


### PR DESCRIPTION
Fixes #11 

### Release notes

- Fixed `GET /api/amlight/flow_stats/flow/stats/ not found` to return 404

Once we're done with the other higher priorities we can cover this with tests, see issue #10  

```
❯ http http://127.0.0.1:8181/api/amlight/flow_stats/flow/stats/00:00:00:00:00:00:00:01
HTTP/1.0 200 OK
Access-Control-Allow-Origin: *
Content-Length: 3
Content-Type: application/json
Date: Tue, 11 Jan 2022 14:22:36 GMT
Server: Werkzeug/1.0.1 Python/3.6.15

[]
```


```
❯ http http://127.0.0.1:8181/api/amlight/flow_stats/flow/stats/00:00:00:00:00:00:00:04
HTTP/1.0 404 NOT FOUND
Access-Control-Allow-Origin: *
Content-Length: 40
Content-Type: text/html; charset=utf-8
Date: Tue, 11 Jan 2022 14:22:38 GMT
Server: Werkzeug/1.0.1 Python/3.6.15

switch 00:00:00:00:00:00:00:04 not found
```
